### PR TITLE
Import OpenResty 1.29.2.4

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
           scan-ref: '.'
@@ -31,7 +31,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-ARG RESTY_BASE_IMAGE_TAG="3.22.3"
+ARG RESTY_BASE_IMAGE_TAG="3.23.4"
 FROM alpine:${RESTY_BASE_IMAGE_TAG}
 ARG RESTY_BASE_IMAGE_TAG
 
 # Docker Build Arguments
-ARG RESTY_VERSION="1.27.1.2"
+ARG RESTY_VERSION="1.29.2.4"
 
 # https://github.com/openresty/openresty-packaging/blob/master/alpine/openresty-openssl3/APKBUILD
-ARG RESTY_OPENSSL_VERSION="3.4.3"
-ARG RESTY_OPENSSL_PATCH_VERSION="3.4.1"
+ARG RESTY_OPENSSL_VERSION="3.5.6"
+ARG RESTY_OPENSSL_PATCH_VERSION="3.5.5"
 ARG RESTY_OPENSSL_URL_BASE="https://github.com/openssl/openssl/releases/download/openssl-${RESTY_OPENSSL_VERSION}"
 ARG RESTY_OPENSSL_BUILD_OPTIONS="enable-camellia enable-rfc3779 enable-ktls enable-fips \
     disable-md2 disable-rc5 disable-weak-ssl-ciphers disable-ssl3 disable-ssl3-method"
 
 # https://github.com/openresty/openresty-packaging/blob/master/alpine/openresty-pcre2/APKBUILD
-ARG RESTY_PCRE_VERSION="10.44"
-ARG RESTY_PCRE_SHA256="86b9cb0aa3bcb7994faa88018292bc704cdbb708e785f7c74352ff6ea7d3175b"
+ARG RESTY_PCRE_VERSION="10.47"
+ARG RESTY_PCRE_SHA256="c08ae2388ef333e8403e670ad70c0a11f1eed021fd88308d7e02f596fcd9dc16"
 ARG RESTY_PCRE_BUILD_OPTIONS="--enable-jit --enable-pcre2grep-jit --disable-bsr-anycrlf --disable-coverage --disable-ebcdic --disable-fuzz-support \
     --disable-jit-sealloc --disable-never-backslash-C --enable-newline-is-lf --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 \
     --enable-pcre2grep-callout --enable-pcre2grep-callout-fork --disable-pcre2grep-libbz2 --disable-pcre2grep-libz --disable-pcre2test-libedit \
@@ -71,7 +71,6 @@ LABEL resty.version="${RESTY_VERSION}" \
       resty.openssl_version="${RESTY_OPENSSL_VERSION}" \
       resty.openssl_patch_version="${RESTY_OPENSSL_PATCH_VERSION}" \
       resty.pcre_version="${RESTY_PCRE_VERSION}" \
-      resty.pcre_sha256="${RESTY_PCRE_SHA256}" \
       resty.geoip2_version="${RESTY_GEOIP2_VERSION}" \
       resty.config_options="${RESTY_CONFIG_OPTIONS}"
 


### PR DESCRIPTION
## Summary

- OpenResty 1.29.2.4
- Alpine 3.23.4
- OpenSSL 3.5.6
- PCRE2 10.47
- trivy-action v0.36.0 (from PR #11)
- codeql-action v4.35.3 (from PR #11)

## Test plan

- [ ] CI build passes (amd64 + arm64)
- [ ] Docker Scout CVE scan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)