### PR TITLE
feat: add four-part version Docker tag (e.g., 1.27.1.2)

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -109,15 +109,18 @@ jobs:
             MAJOR=${BASH_REMATCH[1]}
             MINOR=${BASH_REMATCH[2]}
             PATCH=${BASH_REMATCH[3]}
+            BUILD=${BASH_REMATCH[4]}
 
-            # Docker tags: MAJOR.MINOR.PATCH and MAJOR.MINOR
-            PATCH_VERSION="${MAJOR}.${MINOR}.${PATCH}"  # e.g., 1.27.1
-            MINOR_VERSION="${MAJOR}.${MINOR}"           # e.g., 1.27
+            # Docker tags: MAJOR.MINOR.PATCH.BUILD, MAJOR.MINOR.PATCH, and MAJOR.MINOR
+            FULL_VERSION="${MAJOR}.${MINOR}.${PATCH}.${BUILD}"  # e.g., 1.27.1.2
+            PATCH_VERSION="${MAJOR}.${MINOR}.${PATCH}"          # e.g., 1.27.1
+            MINOR_VERSION="${MAJOR}.${MINOR}"                   # e.g., 1.27
 
+            echo "full_version=$FULL_VERSION" >> $GITHUB_OUTPUT
             echo "patch_version=$PATCH_VERSION" >> $GITHUB_OUTPUT
             echo "minor_version=$MINOR_VERSION" >> $GITHUB_OUTPUT
 
-            echo "Generated Docker tags: $PATCH_VERSION, $MINOR_VERSION"
+            echo "Generated Docker tags: $FULL_VERSION, $PATCH_VERSION, $MINOR_VERSION"
           else
             echo "Tag format does not match expected pattern (X.X.X.X-X)"
           fi
@@ -129,6 +132,7 @@ jobs:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=${{ steps.version.outputs.full_version }},enable=${{ startsWith(github.ref, 'refs/tags/') && steps.version.outputs.full_version != '' }}
             type=raw,value=${{ steps.version.outputs.patch_version }},enable=${{ startsWith(github.ref, 'refs/tags/') && steps.version.outputs.patch_version != '' }}
             type=raw,value=${{ steps.version.outputs.minor_version }},enable=${{ startsWith(github.ref, 'refs/tags/') && steps.version.outputs.minor_version != '' }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,16 +177,16 @@ When updating OpenResty or dependencies:
 - Maintains complete build history
 
 **Docker Tags** (generated automatically):
+- `1.27.1.2` - Four-part version (exact build)
 - `1.27.1` - Three-part version (tracks latest patch within 1.27.1.x)
 - `1.27` - Two-part version (tracks latest minor)
 - `latest` - Latest build from master branch
 
 **Example**: Pushing git tag `1.27.1.2-0` generates Docker tags:
+- `intimatemerger/openresty:1.27.1.2`
 - `intimatemerger/openresty:1.27.1`
 - `intimatemerger/openresty:1.27`
 - `intimatemerger/openresty:latest`
-
-**Note**: Four-part version tags (e.g., `1.27.1.2`) are not published to Docker Hub. Users should use `1.27.1` to get the latest patch version within the 1.27.1.x series.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Git tag `1.27.1.2-0` push時に `1.27.1.2` Docker タグも生成するよう変更
- 従来: `1.27.1`, `1.27`, `latest`
- 変更後: `1.27.1.2`, `1.27.1`, `1.27`, `latest`

## Changes

- `.github/workflows/build-and-push.yaml`: `BASH_REMATCH[4]` から `FULL_VERSION` 抽出し `full_version` output に追加、`docker/metadata-action` のタグ一覧に追加
- `CLAUDE.md`: タグ戦略の記述を更新

## Test plan

- [ ] `1.27.1.2-0` タグ push → Actions で `1.27.1.2` タグが Docker Hub に生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)